### PR TITLE
Ignore all parentheticals and brackets, but give bonus points for guessing them completely correctly

### DIFF
--- a/games/musicquiz/mqgame/gamestate.go
+++ b/games/musicquiz/mqgame/gamestate.go
@@ -662,10 +662,8 @@ func calcSimilarity(target, guess string) (score float64) {
 	originalGuess := guess
 
 	// Normalize both strings for a fair comparison
-	fmt.Printf("'%s' vs '%s'", target, guess)
 	target = normalize(parentheticalsRegexp.ReplaceAllLiteralString(target, ""))
 	guess = normalize(parentheticalsRegexp.ReplaceAllLiteralString(guess, ""))
-	fmt.Printf(" normalized to '%s' vs '%s'\n", target, guess)
 
 	// Otherwise, check similarity
 	dist := editDistance(target, guess)
@@ -686,7 +684,6 @@ func calcSimilarity(target, guess string) (score float64) {
 				strings.Count(targetParen, "[") -
 				strings.Count(targetParen, "]")
 			score += float64(parenLen) / float64(len(target)) / 2.0
-			fmt.Printf("Adding %d / %d to score for matching parens '%s'", parenLen, len(target), targetParen)
 		}
 	}
 
@@ -738,6 +735,5 @@ func editDistance(targetStr string, guessStr string) (distance int) {
 		}
 	}
 
-	fmt.Printf("'%v' vs '%v' -> %v\n", target, guess, editDistances)
 	return editDistances[len(target)][len(guess)]
 }

--- a/games/musicquiz/mqgame/gamestate.go
+++ b/games/musicquiz/mqgame/gamestate.go
@@ -651,31 +651,46 @@ func (mg *multiguessGame) ResetTimer() {
 	mg.lastTimestamp = time.Now()
 }
 
-var ftParentheticalRegexp = regexp.MustCompile(` ?\((ft|feat|featuring)\.?[^)]+\)`)
+var parentheticalsRegexp = regexp.MustCompile(`( ?[[(].+[])])+`)
+
+func normalize(title string) (normalized string) {
+	return strings.ToLower(strings.TrimSpace(title))
+}
 
 func calcSimilarity(target, guess string) (score float64) {
-
-	// Quick exit if it's a perfect guess
-	if strings.EqualFold(target, guess) {
-		return 1
-	}
+	originalTarget := target
+	originalGuess := guess
 
 	// Normalize both strings for a fair comparison
-	// (TODO: Give bonus points for matching the parenthetical later?)
-	target = ftParentheticalRegexp.ReplaceAllLiteralString(target, "")
-	guess = ftParentheticalRegexp.ReplaceAllLiteralString(guess, "")
-	target = strings.ToLower(strings.TrimSpace(target))
-	guess = strings.ToLower(strings.TrimSpace(guess))
-
-	// Quick-ish exit if it's a perfect guess after normalization
-	if strings.EqualFold(target, guess) {
-		return 1
-	}
+	fmt.Printf("'%s' vs '%s'", target, guess)
+	target = normalize(parentheticalsRegexp.ReplaceAllLiteralString(target, ""))
+	guess = normalize(parentheticalsRegexp.ReplaceAllLiteralString(guess, ""))
+	fmt.Printf(" normalized to '%s' vs '%s'\n", target, guess)
 
 	// Otherwise, check similarity
 	dist := editDistance(target, guess)
 	diff := float64(dist) / float64(utf8.RuneCountInString(target))
-	return max(0.0, 1.0 - diff)
+	score = max(0.0, 1.0 - diff)
+
+	// Give back some bonus points if they matched the parentheticals
+	targetParen := normalize(parentheticalsRegexp.FindString(originalTarget))
+	if len(targetParen) > 0 {
+		guessParen := normalize(parentheticalsRegexp.FindString(originalGuess))
+		if targetParen == guessParen {
+			// Your bonus points are proportional to half the length of the parenthetical
+			// (e.g. perfectly guessing an equal-length title and parenthetical gives you
+			// a score of 1.5)
+			parenLen := utf8.RuneCountInString(targetParen) -
+				strings.Count(targetParen, "(") -
+				strings.Count(targetParen, ")") -
+				strings.Count(targetParen, "[") -
+				strings.Count(targetParen, "]")
+			score += float64(parenLen) / float64(len(target)) / 2.0
+			fmt.Printf("Adding %d / %d to score for matching parens '%s'", parenLen, len(target), targetParen)
+		}
+	}
+
+	return score
 }
 
 func editDistance(targetStr string, guessStr string) (distance int) {

--- a/games/musicquiz/mqgame/gamestate.go
+++ b/games/musicquiz/mqgame/gamestate.go
@@ -651,7 +651,7 @@ func (mg *multiguessGame) ResetTimer() {
 	mg.lastTimestamp = time.Now()
 }
 
-var parentheticalsRegexp = regexp.MustCompile(`( ?[[(].+[])])+`)
+var parentheticalsRegexp = regexp.MustCompile(`([[(].+[])])+`)
 
 func normalize(title string) (normalized string) {
 	return strings.ToLower(strings.TrimSpace(title))

--- a/games/musicquiz/mqgame/gamestate_test.go
+++ b/games/musicquiz/mqgame/gamestate_test.go
@@ -15,9 +15,7 @@ func TestCalcSimilarity(t *testing.T) {
 		{"abcd", "BC", 0.5},
 
 		// Unicode awareness: Treat as 1/2 code points, not 1/4 characters
-		{ "$€", "$E", 0.5},
-
-		{"abcd (ft. pants)", "abcd (ft. pants)", 1},
+		{"$€", "$E", 0.5},
 		// (two errors vs. four characters in the proper title,
 		// no substring matching any more)
 		{"abcd (ft. pant)", "abcd (", 0.5},
@@ -28,6 +26,27 @@ func TestCalcSimilarity(t *testing.T) {
 		{"abcd (feat banana pants)", "abcd", 1},
 		{"abcd (featuring banana pants)", "abcd", 1},
 		{"abcd (featuring. banana pants)", "abcd", 1},
+
+		// Ignore all parentheticals
+		{"abcd (Taylor's Version)", "abcd", 1},
+		{"abcd (Taylor's Version) (From The Vault)", "abcd", 1},
+		{"abcd (Taylor's Version) [From The Vault]", "abcd", 1},
+		{"abcd [Club Remix]", "abcd", 1},
+		{"abcd", "abcd (Yes I know it's weird that I know this song)", 1},
+
+		// But, if you guess the parenthetical perfectly, get some bonus points
+		// (the parenthetical is 16 which is 4x the length of the title, so you get 2x as many points)
+		{"abcd (ft. banana pants)", "abcd (ft. banana pants)", 3},
+		{"abcd (ft. banana pants)", "ABCD (FT. BANANA PANTS)", 3},
+		// 9 / 4 / 2 = extra 9/8 points
+		{"abcd (ft. pants)", "abcd (ft. pants)", 2.125},
+		// Getting ANY part of the parenthetical incorrect means no bonus points
+		{"abcd (ft. pants)", "abcd (pants)", 1},
+		{"abcd (ft. pants)", "abcd (ft. paints)", 1},
+		// You can still get bonus points if you ONLY know the parenthetical
+		{"abcd (ft. pants)", "I dunno (ft. pants)", 1.125},
+		// Unicode awareness: Treat as 4 code points, not 8 characters
+		{"abcd (€€€€)", "abcd (€€€€)", 1.5},
 
 		// Spaces on the inside matter, spaces on the outside don't
 		{"abcd", "abcd ", 1},


### PR DESCRIPTION
This one's actually controversial so despite the fact that I have commit access, I'm requesting a review anyway.

* This ignores ALL parentheticals and brackets by default, including those in the guess. Not sure whether you want that by default
  - I think this allows for commentary such as `"(I think this should count)"` in guesses without penalizing your score
  - I also think that all of the `"(ft. whoever)"` and `"(Taylor's Version)"` and `"[NIGHT CLUB REMIX]"` aren't essential to guessing correctly
* You can get bonus points for guessing the parenthetical. Ditto.
  - I'm thinking this is good for things like `"(Taylor's Version)"` and `"(ft. whoever)"` but maybe less good with some tracks that just parenthetical titles, like `"December, 1963 (Oh, What a Night)"`
* Said bonus points depend on the _length_ of the parenthetical
  - I kinda wanted to give bonus points but didn't really know how. Open to suggestions here, because I think comparative length really has no bearing on how "good" you had to be to get the parenthetical, but couldn't come up with an arbitrary flat score that felt meaningful.